### PR TITLE
feat: Add nacl encryption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ p256 = { version = "0.13", features = ["ecdh"] }
 rand_core = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sodiumoxide = "0.2.7"
+
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,9 @@ hex = "0.4.3"
 log = "0.4.22"
 env_logger = "0.11.5"
 tokio = { version = "1.41", features = ["rt", "macros"], default-features = false }
-p256 = { version = "0.13", features = ["ecdh"] }
-rand_core = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sodiumoxide = "0.2.7"
-
 
 [profile.release]
 opt-level = 3

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,10 @@ endif
 
 ifeq ($(DEBUG),1)
 GRAMINE_LOG_LEVEL = debug
+RUST_LOG = debug
 else
 GRAMINE_LOG_LEVEL = error
+RUST_LOG = error
 endif
 
 # Print build mode information
@@ -34,13 +36,14 @@ print-mode:
 	@echo "  Cargo Flags: $(CARGO_FLAGS)"
 
 $(SELF_EXE): Cargo.toml print-mode
-	cargo build --release $(CARGO_FLAGS)
+	RUST_LOG=$(RUST_LOG) cargo build --release $(CARGO_FLAGS)
 
 gramine-sealing-key-provider.manifest: gramine-sealing-key-provider.manifest.template
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
 		-Dself_exe=$(SELF_EXE) \
+		-Drust_log=$(RUST_LOG) \
 		$< $@
 
 gramine-sealing-key-provider.manifest.sgx gramine-sealing-key-provider.sig: sgx_sign

--- a/gramine-sealing-key-provider.manifest.template
+++ b/gramine-sealing-key-provider.manifest.template
@@ -32,6 +32,8 @@ sgx.allowed_files = [
   "file:/etc/resolv.conf",
 ]
 
+sgx.enable_stats = {{ 'true' if log_level == 'debug' else 'false' }}
+
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
   "file:{{ self_exe }}",
@@ -41,6 +43,3 @@ sgx.trusted_files = [
 
 sgx.thread_num = 32
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '32' }}
-
-# Enable enclave measurement for sealing
-sgx.enable_stats = true

--- a/gramine-sealing-key-provider.manifest.template
+++ b/gramine-sealing-key-provider.manifest.template
@@ -8,7 +8,7 @@ loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}"
 loader.env.MALLOC_ARENA_MAX = "1"
 loader.env.RUST_BACKTRACE = "full"
 # Set RUST_LOG based on Gramine log level
-loader.env.RUST_LOG = "{{ 'debug' if log_level == 'debug' else 'info' }}"
+loader.env.RUST_LOG = "{{ rust_log }}"
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },

--- a/src/crypto/keys.rs
+++ b/src/crypto/keys.rs
@@ -1,7 +1,13 @@
 use crate::error::ProviderError;
 use log::{debug, info};
-use p256::PublicKey;
 use sha2::{Digest, Sha256};
+use sodiumoxide::crypto::sealedbox;
+use sodiumoxide::crypto::box_::{self, PublicKey};
+
+// Initialize sodium at program start
+pub fn init_sodium() -> Result<(), ProviderError> {
+    sodiumoxide::init().map_err(|_| ProviderError::CryptoError("Failed to initialize sodium".into()))
+}
 
 pub fn derive_key(sealing_key: &[u8], measurements: &[u8]) -> Vec<u8> {
     info!("Deriving key from measurements");
@@ -19,42 +25,59 @@ pub fn derive_key(sealing_key: &[u8], measurements: &[u8]) -> Vec<u8> {
 
 pub fn extract_public_key(report_data: &[u8]) -> Result<PublicKey, ProviderError> {
     debug!("Extracting public key from report data");
-    // This code is checking for SEC1 formatted compressed public keys
-    // SEC1 format for compressed public keys:
-    // - First byte (0x02 or 0x03) indicates the sign of the y-coordinate
-    // - Followed by the x-coordinate (32 bytes for P-256)
-    // Total length: 33 bytes
-
-    // Check minimum length requirement
-    if report_data.len() < 33 {
-        return Err(ProviderError::PublicKeyError(
-            "Report data too short".into(),
-        ));
-    }
-
-    // Check if it's a valid compressed public key format
-    // 0x02: positive y-coordinate
-    // 0x03: negative y-coordinate
-    if report_data[0] != 0x02 && report_data[0] != 0x03 {
-        return Err(ProviderError::PublicKeyError(
-            "Invalid public key format".into(),
-        ));
-    }
     
-    // Parse the first 33 bytes as a SEC1-encoded public key
-    PublicKey::from_sec1_bytes(&report_data[..33])
-        .map_err(|e| ProviderError::PublicKeyError(e.to_string()))
+    if report_data.len() < box_::PUBLICKEYBYTES {
+        return Err(ProviderError::PublicKeyError(format!(
+            "Report data too short. Expected {} bytes", box_::PUBLICKEYBYTES
+        )));
+    }
+
+    PublicKey::from_slice(&report_data[..box_::PUBLICKEYBYTES])
+        .ok_or_else(|| ProviderError::PublicKeyError("Invalid public key format".into()))
 }
 
 pub fn encrypt_key(derived_key: &[u8], public_key: &PublicKey) -> Result<Vec<u8>, ProviderError> {
-    info!("Encrypting derived key using provided public key");
+    info!("Encrypting derived key using sealed box");
     debug!("Input key length: {} bytes", derived_key.len());
-    debug!("Input key (hex): {}", hex::encode(derived_key));
-    debug!("Public key: {:?}", public_key);
-
-    // TODO: Implement actual public key encryption
-    let encrypted = derived_key.to_vec();
-
+    
+    let encrypted = sealedbox::seal(derived_key, public_key);
+    
     debug!("Encrypted data length: {} bytes", encrypted.len());
+    debug!("Encrypted data (hex): {}", hex::encode(&encrypted));
+    
     Ok(encrypted)
 }
+
+/*pub fn encrypt_key(derived_key: &[u8], public_key: &PublicKey) -> Result<Vec<u8>, ProviderError> {
+    info!("Encrypting derived key using NaCl box");
+    debug!("Input key length: {} bytes", derived_key.len());
+    debug!("Public key: {:?}", hex::encode(public_key.as_ref()));
+
+    // Generate ephemeral keypair for encryption
+    let (ephemeral_pk, ephemeral_sk) = box_::gen_keypair();
+    
+    // Generate nonce
+    let nonce = box_::gen_nonce();
+    
+    // Encrypt the derived key
+    let encrypted = box_::seal(
+        derived_key,
+        &nonce,
+        public_key,
+        &ephemeral_sk
+    );
+
+    // Format the response: ephemeral_pk + nonce + ciphertext
+    let mut result = Vec::with_capacity(
+        box_::PUBLICKEYBYTES + // ephemeral public key
+        box_::NONCEBYTES +     // nonce
+        encrypted.len()        // ciphertext
+    );
+    
+    result.extend_from_slice(ephemeral_pk.as_ref());
+    result.extend_from_slice(nonce.as_ref());
+    result.extend_from_slice(&encrypted);
+
+    debug!("Final encrypted data length: {} bytes", result.len());
+    Ok(result)
+}*/

--- a/src/crypto/keys.rs
+++ b/src/crypto/keys.rs
@@ -41,43 +41,9 @@ pub fn encrypt_key(derived_key: &[u8], public_key: &PublicKey) -> Result<Vec<u8>
     debug!("Input key length: {} bytes", derived_key.len());
     
     let encrypted = sealedbox::seal(derived_key, public_key);
-    
+
     debug!("Encrypted data length: {} bytes", encrypted.len());
     debug!("Encrypted data (hex): {}", hex::encode(&encrypted));
     
     Ok(encrypted)
 }
-
-/*pub fn encrypt_key(derived_key: &[u8], public_key: &PublicKey) -> Result<Vec<u8>, ProviderError> {
-    info!("Encrypting derived key using NaCl box");
-    debug!("Input key length: {} bytes", derived_key.len());
-    debug!("Public key: {:?}", hex::encode(public_key.as_ref()));
-
-    // Generate ephemeral keypair for encryption
-    let (ephemeral_pk, ephemeral_sk) = box_::gen_keypair();
-    
-    // Generate nonce
-    let nonce = box_::gen_nonce();
-    
-    // Encrypt the derived key
-    let encrypted = box_::seal(
-        derived_key,
-        &nonce,
-        public_key,
-        &ephemeral_sk
-    );
-
-    // Format the response: ephemeral_pk + nonce + ciphertext
-    let mut result = Vec::with_capacity(
-        box_::PUBLICKEYBYTES + // ephemeral public key
-        box_::NONCEBYTES +     // nonce
-        encrypted.len()        // ciphertext
-    );
-    
-    result.extend_from_slice(ephemeral_pk.as_ref());
-    result.extend_from_slice(nonce.as_ref());
-    result.extend_from_slice(&encrypted);
-
-    debug!("Final encrypted data length: {} bytes", result.len());
-    Ok(result)
-}*/

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,3 +1,3 @@
 mod keys;
 
-pub use keys::{derive_key, encrypt_key, extract_public_key};
+pub use keys::{derive_key, encrypt_key, extract_public_key, init_sodium};

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), ProviderError> {
+    info!("Initializing sodiumoxide");
+    crypto::init_sodium()?;
+
     env_logger::init();
     info!("Starting Gramine Sealing Key Provider");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,9 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), ProviderError> {
-    info!("Initializing sodiumoxide");
+    // Initialize sodium first
     crypto::init_sodium()?;
-
+    
     env_logger::init();
     info!("Starting Gramine Sealing Key Provider");
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,6 +12,7 @@ struct QuoteRequest {
 
 #[derive(Serialize, Deserialize)]
 struct QuoteResponse {
+    encrypted_key: Vec<u8>,
     provider_quote: Vec<u8>,
 }
 
@@ -72,6 +73,7 @@ async fn handle_connection(mut socket: TcpStream) -> Result<(), ProviderError> {
     
     // Prepare response
     let response = QuoteResponse {
+        encrypted_key: provider_response.encrypted_key,
         provider_quote: provider_response.provider_quote,
     };
 

--- a/test_client.py
+++ b/test_client.py
@@ -2,11 +2,81 @@ import socket
 import json
 import struct
 import sys
+import hashlib
+import binascii
+
+class SGXQuoteConstants:
+    HEADER_SIZE = 48
+    REPORT_BODY_OFFSET = HEADER_SIZE
+    REPORT_BODY_SIZE = 384
+    REPORT_DATA_OFFSET = REPORT_BODY_OFFSET + 320  # Report data is 64 bytes, towards end of report body
+    REPORT_DATA_SIZE = 64
+
+def hex_print(label, data):
+    """Helper function to print hex data with label"""
+    if isinstance(data, list):
+        data = bytes(data)
+    elif isinstance(data, str):
+        data = bytes.fromhex(data)
+    print(f"{label}:\n  Length: {len(data)} bytes\n  Hex: {data.hex()}")
+
+def calculate_hash(data):
+    """Calculate SHA256 hash of data"""
+    if isinstance(data, list):
+        data = bytes(data)
+    hasher = hashlib.sha256()
+    hasher.update(data)
+    return hasher.digest()
+
+def extract_report_data(quote):
+    """Extract report data from SGX quote"""
+    try:
+        # Report data is 64 bytes at offset 320 in the report body
+        # Report body starts after the quote header
+        report_data = quote[SGXQuoteConstants.REPORT_DATA_OFFSET:
+                          SGXQuoteConstants.REPORT_DATA_OFFSET + SGXQuoteConstants.REPORT_DATA_SIZE]
+        
+        # First 32 bytes contain our hash
+        return report_data[:32]
+    except Exception as e:
+        print(f"Error extracting report data: {e}")
+        return None
+
+def verify_response(encrypted_key, provider_quote):
+    """Verify the response by checking hash in quote's report data"""
+    try:
+        # Calculate hash of encrypted key
+        calculated_hash = calculate_hash(encrypted_key)
+        hex_print("Calculated hash of encrypted key", calculated_hash)
+
+        # Extract report data from quote
+        stored_hash = extract_report_data(provider_quote)
+        if stored_hash is None:
+            print("Failed to extract report data from quote")
+            return False
+            
+        hex_print("Hash from quote's report data", stored_hash)
+
+        # Compare hashes
+        if calculated_hash == stored_hash:
+            print("\nHash verification: SUCCESS")
+            return True
+        else:
+            print("\nHash verification: FAILED")
+            return False
+
+    except Exception as e:
+        print(f"\nVerification error: {e}")
+        return False
 
 def send_quote(host='localhost', port=3443, quote_path='quotes/tdxQuote.txt'):
+    print(f"\nReading quote from: {quote_path}")
+    
     # Read the quote file
     with open(quote_path, 'rb') as f:
         quote_data = f.read()
+    
+    hex_print("Input quote", quote_data)
     
     # Create request
     request = {
@@ -16,22 +86,51 @@ def send_quote(host='localhost', port=3443, quote_path='quotes/tdxQuote.txt'):
     # Serialize request
     request_json = json.dumps(request).encode()
     
+    print("\nConnecting to server...")
     # Connect and send
     with socket.create_connection((host, port)) as sock:
+        print(f"Connected to {host}:{port}")
+        
         # Send length
         sock.send(struct.pack('>I', len(request_json)))
         # Send data
         sock.send(request_json)
+        print("Quote sent, waiting for response...")
         
         # Read response length
         resp_len = struct.unpack('>I', sock.recv(4))[0]
+        print(f"Expected response length: {resp_len} bytes")
+        
         # Read response
         response = sock.recv(resp_len)
         
-        # Parse and print response
+        # Parse response
         resp_data = json.loads(response)
-        print(f"Received encrypted key: {bytes(resp_data['encrypted_key']).hex()}")
+        
+        print("\nResponse received:")
+        encrypted_key = bytes(resp_data['encrypted_key'])
+        provider_quote = bytes(resp_data['provider_quote'])
+        
+        hex_print("Encrypted key", encrypted_key)
+        hex_print("Provider quote", provider_quote)
+        
+        print("\nVerifying response...")
+        verify_response(encrypted_key, provider_quote)
+
+def main():
+    # Parse command line arguments
+    if len(sys.argv) > 1:
+        quote_path = sys.argv[1]
+    else:
+        quote_path = 'quotes/tdxQuote.txt'
+        print(f"No quote path provided, using default: {quote_path}")
+
+    try:
+        send_quote(quote_path=quote_path)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
 
 if __name__ == '__main__':
-    quote_path = sys.argv[1] if len(sys.argv) > 1 else 'quotes/tdxQuote.txt'
-    send_quote(quote_path=quote_path)
+    main()
+


### PR DESCRIPTION
This is currently broken because encrypting the derived key in any way causes the cipher text result to be of size > 64 bytes.
This exceeds the user report data in the SGX quote, causing gramine to return an error.
Another solutions could be to either split the result into two responses or return the encrypted derived key with its hashed signed and put inside the quote instead 🤔  
@amiller what do you think

Here is a snippet from the error output:
```
[2024-11-22T18:11:21Z DEBUG gramine_sealing_key_provider::crypto::keys] Encrypted data (hex): 5627baab5fe3181c02c51806c4202aba503eb550f62f8b7f81aaa83a00d4e07506123cc95130f8469d53c3f30927f16bb12b5f1305baa3a5a35c15188a9d055688f15c812d4878ec8dcd5ecfdef973de
[2024-11-22T18:11:21Z DEBUG gramine_sealing_key_provider::quote::handler] Getting final quote with encrypted key in report data
[2024-11-22T18:11:21Z DEBUG gramine_sealing_key_provider::gramine::interface] Setting user report data and getting quote
[2024-11-22T18:11:21Z DEBUG gramine_sealing_key_provider::gramine::interface] Setting user report data: 80 bytes
(libos_epoll.c:433:do_epoll_del) [P1:T2:gramine-sealing-key...] debug: epoll: deleted 7 (0xf1dd3f8) from epoll handle 0xf1dcd68
[2024-11-22T18:11:21Z ERROR gramine_sealing_key_provider::server] Connection error from 127.0.0.1:49206: Crypto error: User report data must not exceed 64 bytes
```


Edit: fixed it by returning [encrypted derived key, SGX quote with the hash of the encrypted derived key in the user report data]