### PR TITLE
Turns on /etc/resolv.conf emulation

### DIFF
--- a/gramine-sealing-key-provider.manifest.template
+++ b/gramine-sealing-key-provider.manifest.template
@@ -26,11 +26,11 @@ loader.env.TOKIO_WORKER_THREADS = "1"
 
 sys.insecure__allow_eventfd = true
 
+# Turn on /etc/resolv.conf emulation
+sys.enable_extra_runtime_domain_names_conf = true
+
 # Required files and devices for quote generation and key access
-sgx.allowed_files = [
-  "file:/etc/hosts",
-  "file:/etc/resolv.conf",
-]
+sgx.allowed_files = []
 
 sgx.enable_stats = {{ 'true' if log_level == 'debug' else 'false' }}
 


### PR DESCRIPTION
As PR #3 is not active, I am submitting this PR to solve the quote verification failure in non-dev mode.

Instead of mounting `/etc/resolv.conf` directly, this PR uses the Gramine-built-in emulation. This approach enables the runtime to filter potentially harmful information from the host resolv.conf.