### PR TITLE
Update dcap-qvl to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 dev-mode = []
 
 [dependencies]
-dcap-qvl = "0.1.5"
+dcap-qvl = "0.2.0"
 base64 = "0.22.1"
 sha2 = "0.10"
 thiserror = "2.0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,12 +33,6 @@ pub enum ProviderError {
     CryptoError(String),
 }
 
-impl From<dcap_qvl::Error> for ProviderError {
-    fn from(_: dcap_qvl::Error) -> Self {
-        ProviderError::DcapError
-    }
-}
-
 impl From<serde_json::Error> for ProviderError {
     fn from(e: serde_json::Error) -> Self {
         ProviderError::SerializationError(e.to_string())

--- a/src/quote/handler.rs
+++ b/src/quote/handler.rs
@@ -23,7 +23,7 @@ pub async fn process_quotes(tdx_quote_data: &[u8]) -> Result<ProviderResponse, P
     debug!("Input quote (hex): {}", hex::encode(tdx_quote_data));
 
     // 1. Verify TDX quote
-    verify_quote(tdx_quote_data).await?;
+    verify_quote(tdx_quote_data).await.or(Err(ProviderError::DcapError))?;
 
     // 2. Parse TDX quote early
     let tdx_quote = parse_quote(tdx_quote_data.to_vec())?;


### PR DESCRIPTION
v0.2.0 fixed a potential panic in `verify` when the pck cert chain is missing in the quote.