### PR TITLE
chore: update manifest for noble gramine version

### DIFF
--- a/gramine-sealing-key-provider.manifest.template
+++ b/gramine-sealing-key-provider.manifest.template
@@ -41,5 +41,4 @@ sgx.trusted_files = [
   "file:{{ arch_libdir }}/",
 ]
 
-sgx.thread_num = 32
 sgx.max_threads = {{ '1' if env.get('EDMM', '0') == '1' else '32' }}


### PR DESCRIPTION
sgx.thread_num is deprecated and replaced by sgx.max_threads
This PR fixes the issue not compiling for newer gramine versions