### PR TITLE
Upgrade dcap-qvl to 0.3.10 to fix security vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 dev-mode = []
 
 [dependencies]
-dcap-qvl = "0.2.0"
+dcap-qvl = "0.3.10"
 base64 = "0.22.1"
 sha2 = "0.10"
 thiserror = "2.0.3"

--- a/src/quote/handler.rs
+++ b/src/quote/handler.rs
@@ -95,7 +95,7 @@ async fn verify_quote(quote_data: &[u8]) -> Result<(), ProviderError> {
 
     debug!("Verifying quote with DCAP");
 
-    let collateral = get_collateral_from_pcs(quote_data, std::time::Duration::from_secs(10))
+    let collateral = get_collateral_from_pcs(quote_data)
         .await
         .map_err(|_| ProviderError::QuoteVerificationError)?;
 


### PR DESCRIPTION
## Summary

Upgrade dcap-qvl from 0.2.0 to 0.3.10 to fix security vulnerability.

## Security Advisory
- https://github.com/Phala-Network/dcap-qvl/security/advisories/GHSA-796p-j2gh-9m2q

## Changes

- Update dcap-qvl dependency from 0.2.0 to 0.3.10
- Adapt to API change: `get_collateral_from_pcs` no longer takes timeout parameter

## Test plan

- [x] Verified cargo build succeeds