### PR TITLE
chore: remove sgx.enable_stats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gramineproject/gramine:1.9-jammy@sha256:84b3d222e0bd9ab941f0078a462af0dbc55
 
 # Install Rust 1.85 and build dependencies
 RUN apt-get update && apt-get install -y \
-    build-essential \
+    build-essential=12.9ubuntu3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.85 -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gramineproject/gramine:1.9-jammy@sha256:84b3d222e0bd9ab941f0078a462af0dbc55
 
 # Install Rust 1.85 and build dependencies
 RUN apt-get update && apt-get install -y \
-    build-essential=12.8ubuntu1.1 \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.85 -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM gramineproject/gramine:v1.5@sha256:615849089db84477f03cd13209c08eaf6b6a3a68b4df733e097db56781935589
+FROM gramineproject/gramine:1.9-jammy@sha256:84b3d222e0bd9ab941f0078a462af0dbc5518156b99b147c10a7b83722ac0c38
 
-# Install Rust 1.80 and build dependencies
+# Install Rust 1.85 and build dependencies
 RUN apt-get update && apt-get install -y \
     build-essential=12.8ubuntu1.1 \
     && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sequenceDiagram
 
 - Intel CPU with SGX and TDX support
 - Gramine installed (version 1.9 or higher)
-- Rust toolchain (tested with rustc 1.82.0)
+- Rust toolchain (tested with rustc 1.85.0)
 - DCAP driver and related software stack
 - Linux environment (Ubuntu 22.04 LTS)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ sequenceDiagram
 ## Prerequisites
 
 - Intel CPU with SGX and TDX support
-- Gramine installed (version 1.5 or higher)
+- Gramine installed (version 1.9 or higher)
 - Rust toolchain (tested with rustc 1.82.0)
 - DCAP driver and related software stack
 - Linux environment (Ubuntu 22.04 LTS)

--- a/gramine-sealing-key-provider.manifest.template
+++ b/gramine-sealing-key-provider.manifest.template
@@ -1,5 +1,4 @@
 # Gramine manifest template for Sealing Key Provider
-loader.entrypoint = "file:{{ gramine.libos }}"
 libos.entrypoint = "{{ self_exe }}"
 
 loader.log_level = "{{ log_level }}"
@@ -35,7 +34,6 @@ sgx.allowed_files = []
 sgx.enable_stats = {{ 'true' if log_level == 'debug' else 'false' }}
 
 sgx.trusted_files = [
-  "file:{{ gramine.libos }}",
   "file:{{ self_exe }}",
   "file:{{ gramine.runtimedir() }}/",
   "file:{{ arch_libdir }}/",

--- a/gramine-sealing-key-provider.manifest.template
+++ b/gramine-sealing-key-provider.manifest.template
@@ -29,8 +29,6 @@ sys.enable_extra_runtime_domain_names_conf = true
 # Required files and devices for quote generation and key access
 sgx.allowed_files = []
 
-sgx.enable_stats = {{ 'true' if log_level == 'debug' else 'false' }}
-
 sgx.trusted_files = [
   "file:{{ self_exe }}",
   "file:{{ gramine.runtimedir() }}/",

--- a/gramine-sealing-key-provider.manifest.template
+++ b/gramine-sealing-key-provider.manifest.template
@@ -23,8 +23,6 @@ sgx.remote_attestation = "dcap"
 # Reduce number of worker threads for tokio
 loader.env.TOKIO_WORKER_THREADS = "1"
 
-sys.insecure__allow_eventfd = true
-
 # Turn on /etc/resolv.conf emulation
 sys.enable_extra_runtime_domain_names_conf = true
 


### PR DESCRIPTION
Removed sgx.enable_stats from the manifest template as it requires both sgx.debug to be enabled as well as gramine itself to be built with debug flags `--buildtype=debug` or `--buildtype=debugoptimized`  (check gramine [manifest-syntax doc](https://gramine.readthedocs.io/en/v1.9/manifest-syntax.html#enabling-sgx-enclave-stats)) 